### PR TITLE
fix(valkey): stable claim-derived RedisCluster Service name

### DIFF
--- a/features/valkey.feature
+++ b/features/valkey.feature
@@ -15,7 +15,7 @@ Feature: Valkey Data Service
 
   @component:mimir-valkey @phase:1  Scenario: Valkey Functional Validation
     Given the ValkeyCluster Claim "valkey-test" is applied
-    Then I should be able to connect to "valkey-test-valkey-leader.valkey.svc:6379"
+    Then I should be able to connect to "valkey-test-leader.valkey.svc:6379"
     And I should receive a "PONG" response
 
   @component:mimir-valkey @phase:2  Scenario: Valkey Persistence

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -8,6 +8,15 @@ To provision a Valkey cluster, create a `ValkeyCluster` claim in your applicatio
 
 See `claim.yaml` for an example.
 
+> **Claim names must be globally unique across the cluster.** Every
+> `ValkeyCluster`, regardless of the namespace its claim lives in, is
+> materialized as a single `RedisCluster` in the shared `valkey` namespace,
+> named after the claim (`crossplane.io/claim-name`). Two claims with the same
+> name in different namespaces would target the same `RedisCluster`. This is the
+> deliberate trade-off that makes the leader Service hostname stable and
+> predictable (see Connection Details) — pick a distinct claim name per vended
+> instance (e.g. `harbor-valkey`).
+
 ### Parameters
 - `replicas`: Number of nodes (default: 3).
 - `storageSize`: PVC size for storage per node (default: "1Gi").

--- a/valkey/README.md
+++ b/valkey/README.md
@@ -26,13 +26,14 @@ To verify the service works:
     kubectl get valkeyclusters -n mimir
     ```
 3.  **Connection Details**:
-    The service name depends on the generated Composite name.
-    
-    Get the Hostname:
+    The service name is **stable and derived from the claim name** — the
+    composition names the `RedisCluster` after the claim (`crossplane.io/claim-name`),
+    so a claim named `<claim>` always yields the leader Service `<claim>-leader.valkey.svc`.
+    Consumers can hardcode this host; no need to scrape the generated composite name.
+
     ```bash
-    COMPOSITE_NAME=$(kubectl get valkeycluster valkey-test -n mimir -o jsonpath='{.spec.resourceRef.name}')
-    VALKEY_HOST="${COMPOSITE_NAME}-leader.valkey.svc"
-    echo $VALKEY_HOST
+    # For the example claim `valkey-test`:
+    VALKEY_HOST="valkey-test-leader.valkey.svc"
     ```
     - Port: `6379`
 

--- a/valkey/composition.yaml
+++ b/valkey/composition.yaml
@@ -22,7 +22,7 @@ spec:
           apiVersion: kubernetes.crossplane.io/v1alpha2
           kind: Object
           metadata:
-            name: {{ .observed.composite.resource.metadata.name }}-valkey
+            name: {{ index .observed.composite.resource.metadata.labels "crossplane.io/claim-name" | default .observed.composite.resource.metadata.name }}-valkey
             annotations:
               gotemplating.fn.crossplane.io/composition-resource-name: valkey-cluster
           spec:
@@ -34,7 +34,7 @@ spec:
                 apiVersion: redis.redis.opstreelabs.in/v1beta2
                 kind: RedisCluster
                 metadata:
-                  name: {{ .observed.composite.resource.metadata.name }}
+                  name: {{ index .observed.composite.resource.metadata.labels "crossplane.io/claim-name" | default .observed.composite.resource.metadata.name }}
                   namespace: valkey
                 spec:
                   clusterSize: {{ .observed.composite.resource.spec.parameters.replicas }}

--- a/valkey/xrd.yaml
+++ b/valkey/xrd.yaml
@@ -7,6 +7,11 @@ spec:
   names:
     kind: XValkeyCluster
     plural: xvalkeyclusters
+  # NOTE: the composition names the RedisCluster (and thus its leader Service)
+  # after the claim, in the shared `valkey` namespace — so claim names must be
+  # globally unique across the cluster. Two claims with the same name in
+  # different namespaces would collide on one RedisCluster. This is the
+  # trade-off that gives consumers a stable `<claim>-leader.valkey.svc` host.
   claimNames:
     kind: ValkeyCluster
     plural: valkeyclusters

--- a/verify-job.yaml
+++ b/verify-job.yaml
@@ -8,6 +8,6 @@ spec:
       containers:
       - name: verify
         image: valkey/valkey:8.0
-        command: ["sh", "-c", "valkey-cli -h valkey-test-valkey-leader.valkey.svc -p 6379 ping | grep PONG"]
+        command: ["sh", "-c", "valkey-cli -h valkey-test-leader.valkey.svc -p 6379 ping | grep PONG"]
       restartPolicy: Never
   backoffLimit: 1


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- The valkey composition named the `RedisCluster` after the composite's generated name, so the OT-Container-Kit operator's leader Service got an unstable `<claim>-<hash>-leader` host — nothing external could target it.
- Derive the `RedisCluster` (and Object-wrapper) name from `crossplane.io/claim-name` (falling back to the composite name), mirroring the percona Postgres/MySQL/Mongo compositions. A `<claim>` claim now yields the stable leader Service `<claim>-leader.valkey.svc`.
- Corrects the always-wrong `valkey-test-valkey-leader` host hardcoded in `verify-job.yaml` and `features/valkey.feature` (that `-valkey` suffix only ever belonged to the provider-kubernetes Object wrapper, never the `RedisCluster`), and documents the stable naming in the valkey README.

## Why

Unblocks vending redis to Harbor off the bundled photon image: Harbor's `redis.external.addr` can now point at a fixed `harbor-valkey-leader.valkey.svc` instead of scraping the generated composite name.

## Test plan

- [ ] `crossplane render` the valkey composition against a `ValkeyCluster` claim fixture → the emitted `RedisCluster` is named after the claim (`valkey-test`), not `valkey-test-<hash>`.
- [ ] Live: apply the `valkey-test` claim, wait for Ready, and confirm the leader Service resolves at `valkey-test-leader.valkey.svc:6379` (the corrected `verify-job.yaml` returns `PONG`).
- [ ] e2e/kuttl `tests/e2e/valkey` still passes (asserts on the claim's Ready/Synced conditions, unaffected by the internal rename).

## Related

- Prepares mimir for the Harbor stack-member graduation (nidavellir `eitri/harbor`) redis-vending step.
